### PR TITLE
Fix environment reference OPENCTI_TOKEN #3

### DIFF
--- a/opencti/Chart.yaml
+++ b/opencti/Chart.yaml
@@ -8,8 +8,8 @@ maintainers:
     url: https://ialejandro.rocks
 sources:
   - https://github.com/OpenCTI-Platform/opencti
-version: 1.2.5
-appVersion: "6.2.3"
+version: 1.2.6
+appVersion: "6.2.6"
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti

--- a/opencti/templates/connector/deployment.yaml
+++ b/opencti/templates/connector/deployment.yaml
@@ -68,13 +68,8 @@ spec:
           {{- end }}
           {{- end }}
 
-          {{- if and (not (hasKey $envList "OPENCTI_TOKEN")) (.env.APP__ADMIN__TOKEN) }}
-          - name: OPENCTI_TOKEN
-            value: "{{ .env.APP__ADMIN__TOKEN }}"
-          {{- end }}
-
           # Special handling for OPENCTI_URL which is constructed from other values
-          {{- if not (hasKey $.Values.env "OPENCTI_URL") }}
+          {{- if not (hasKey $envList "OPENCTI_URL") }}
           {{- if eq $.Values.env.APP__BASE_PATH "/" }}
           - name: OPENCTI_URL
             value: "http://{{ include "opencti.fullname" $ }}-server:{{ $.Values.service.port }}"
@@ -82,6 +77,11 @@ spec:
           - name: OPENCTI_URL
             value: "http://{{ include "opencti.fullname" $ }}-server:{{ $.Values.service.port }}{{ $.Values.env.APP__BASE_PATH }}"
           {{- end }}
+          {{- end }}
+
+          {{- if and (not (hasKey $envList "OPENCTI_TOKEN")) ($.Values.env.APP__ADMIN__TOKEN) }}
+          - name: OPENCTI_TOKEN
+            value: "{{ $.Values.env.APP__ADMIN__TOKEN }}"
           {{- end }}
 
           # Add Variables in plain text if they were not already added from secrets
@@ -94,7 +94,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-          
+
           resources:
             {{- toYaml .resources | nindent 12 }}
       {{- with .nodeSelector }}


### PR DESCRIPTION
Fixed `OPENCTI_TOKEN` reference on `connector` deployment.

close #3 