### PR TITLE
[opencti] Bump version to 6.2.12

### DIFF
--- a/opencti/Chart.yaml
+++ b/opencti/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 sources:
   - https://github.com/OpenCTI-Platform/opencti
 version: 1.2.8
-appVersion: 6.2.11
+appVersion: 6.2.12
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti


### PR DESCRIPTION
Bump OpenCTI version:
- :information_source: Current: `6.2.11`
- :up: Upgrade: `6.2.12`

Changelog: https://github.com/OpenCTI-Platform/opencti/releases/tag/6.2.12