### PR TITLE
[opencti] new release: filigran-beta-denorm6

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 sources:
   - https://github.com/OpenCTI-Platform/opencti
 version: 1.0.0
-appVersion: 6.2.12
+appVersion: filigran-beta-denorm6
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti


### PR DESCRIPTION
OpenCTI version:
- :information_source: Current: `6.2.12`
- :up: Upgrade: `filigran-beta-denorm6`

Changelog: https://github.com/OpenCTI-Platform/opencti/releases/tag/filigran-beta-denorm6