### PR TITLE
[opencti] new release: filigran-beta-denorm6

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 sources:
   - https://github.com/OpenCTI-Platform/opencti
 version: 1.0.0
-appVersion: 6.2.12
+appVersion: filigran-beta-denorm6
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,11 +16,11 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | elasticsearch | 21.2.* |
-| https://charts.bitnami.com/bitnami | minio | 14.6.* |
-| https://charts.bitnami.com/bitnami | rabbitmq | 14.5.* |
-| https://charts.bitnami.com/bitnami | redis | 19.6.* |
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.21.* |
+| https://charts.bitnami.com/bitnami | elasticsearch | 21.2.8 |
+| https://charts.bitnami.com/bitnami | minio | 14.6.31 |
+| https://charts.bitnami.com/bitnami | rabbitmq | 14.5.0 |
+| https://charts.bitnami.com/bitnami | redis | 19.6.4 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.21.0 |
 
 ## Add repository
 


### PR DESCRIPTION
OpenCTI version:
- :information_source: Current: `6.2.12`
- :up: Upgrade: `filigran-beta-denorm6`

Changelog: https://github.com/OpenCTI-Platform/opencti/releases/tag/filigran-beta-denorm6