### PR TITLE
[opencti] upgrade major dependencies (2024-08-12)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.6.32
+    version: 14.7.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
@@ -31,6 +31,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 19.6.4
+    version: 20.0.1
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -18,9 +18,9 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 |------------|------|---------|
 | https://opensearch-project.github.io/helm-charts/ | opensearch | 2.22.0 |
 | oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.6 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.6.32 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.0 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.6 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 19.6.4 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.0.1 |
 
 ## Add repository
 


### PR DESCRIPTION
========

elasticsearch
-------------
✔ - no change detected:
	* key "$.dependencies[0].version" already set to "21.3.6", from file "charts/opencti/Chart.yaml"

redis
-----
⚠ - change detected:
	* key "$.dependencies[4].version" updated from "19.6.4" to "20.0.1", in file "charts/opencti/Chart.yaml"

rabbitmq
--------
✔ - no change detected:
	* key "$.dependencies[3].version" already set to "14.6.6", from file "charts/opencti/Chart.yaml"

opensearch
----------
✔ - no change detected:
	* key "$.dependencies[2].version" already set to "2.22.0", from file "charts/opencti/Chart.yaml"

minio
-----
⚠ - change detected:
	* key "$.dependencies[1].version" updated from "14.6.32" to "14.7.0", in file "charts/opencti/Chart.yaml"


