### PR TITLE
Allow initContainer images to be pulled from private registry

### DIFF
--- a/charts/opencti/templates/server/deployment.yaml
+++ b/charts/opencti/templates/server/deployment.yaml
@@ -41,7 +41,11 @@ spec:
       initContainers:
       {{- range $service := .Values.readyChecker.services }}
       - name: ready-checker-{{ $service.name }}
+        {{- if $.Values.global.imageRegistry }}
+        image: "{{ $.Values.global.imageRegistry }}/busybox:latest"
+        {{- else }}
         image: busybox:latest
+        {{- end }}
         command:
           - 'sh'
           - '-c'

--- a/charts/opencti/templates/tests/test-connection.yaml
+++ b/charts/opencti/templates/tests/test-connection.yaml
@@ -10,7 +10,11 @@ metadata:
 spec:
   containers:
     - name: wget
+      {{- if .Values.global.imageRegistry }}
+      image: "{{ .Values.global.imageRegistry }}/busybox"
+      {{- else }}
       image: busybox
+      {{- end }}
       command: ['wget']
       args: ['{{ include "opencti.fullname" . }}:{{ .Values.service.targetPort | default .Values.service.port }}']
   restartPolicy: Never

--- a/charts/opencti/templates/worker/deployment.yaml
+++ b/charts/opencti/templates/worker/deployment.yaml
@@ -41,7 +41,11 @@ spec:
       {{- if .Values.readyChecker.enabled }}
       initContainers:
       - name: ready-checker-server
+        {{- if $.Values.global.imageRegistry }}
+        image: "{{ $.Values.global.imageRegistry }}/busybox:latest"
+        {{- else }}
         image: busybox:latest
+        {{- end }}
         command:
           - 'sh'
           - '-c'


### PR DESCRIPTION
Currently, initContainer image busybox:latest can only be pulled from docker hub. And it can't be pulled from a private image registry. This PR intends to resolve this issue.

@ialejandro , let me know your comments/feedback.
