### PR TITLE
[opencti] upgrade minor dependencies (2024-08-19)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -15,15 +15,15 @@ keywords:
   - opencti
 dependencies:
   - name: elasticsearch
-    version: 21.3.6
+    version: 21.3.8
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.6.32
+    version: 14.7.1
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
-    version: 2.22.0
+    version: 2.22.1
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,9 +16,9 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.22.0 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.6 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.6.32 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.22.1 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.8 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.1 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.6 |
 | oci://registry-1.docker.io/bitnamicharts | redis | 19.6.4 |
 


### PR DESCRIPTION
opensearch
----------

* **Current**: `2.22.0`
* **Upgrade**: `2.22.1`
* **Changelog**: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch/opensearch/2.22.1

minio
-----

* **Current**: `14.6.32`
* **Upgrade**: `14.7.1`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.7.1

elasticsearch
-------------

* **Current**: `21.3.6`
* **Upgrade**: `21.3.8`
* Changelog: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.8

