### PR TITLE
[opencti] upgrade minor dependencies (2024-08-26)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
-    version: 2.22.1
+    version: 2.23.0
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,7 +16,7 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.22.1 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.23.0 |
 | oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.8 |
 | oci://registry-1.docker.io/bitnamicharts | minio | 14.7.1 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.6 |


### PR DESCRIPTION
opensearch
----------

* **Current**: `2.22.1`
* **Upgrade**: `2.23.0`
* **Changelog**: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch/opensearch/2.23.0

