### PR TITLE
fix: release name on ready-checker

### DIFF
--- a/charts/opencti/templates/server/deployment.yaml
+++ b/charts/opencti/templates/server/deployment.yaml
@@ -49,7 +49,15 @@ spec:
         command:
           - 'sh'
           - '-c'
-          - 'RETRY=0; until [ $RETRY -eq {{ $.Values.readyChecker.retries }} ]; do nc -zv {{ $.Values.fullnameOverride | default $.Release.Name }}-{{ $service.name }} {{ $service.port }} && break; echo "[$RETRY/{{ $.Values.readyChecker.retries }}] waiting service {{ $.Values.fullnameOverride | default $.Release.Name }}-{{ $service.name }}:{{ $service.port }} is ready"; sleep {{ $.Values.readyChecker.timeout }}; RETRY=$(($RETRY + 1)); done'
+          - |
+            RETRY=0;
+            until [ $RETRY -eq {{ $.Values.readyChecker.retries }} ];
+            do
+              nc -zv {{ $.Values.fullnameOverride | default $.Release.Name }}-{{ $service.name }} {{ $service.port }} && break;
+              echo "[$RETRY/{{ $.Values.readyChecker.retries }}] waiting service {{ $.Values.fullnameOverride | default $.Release.Name }}-{{ $service.name }}:{{ $service.port }} is ready";
+              sleep {{ $.Values.readyChecker.timeout }};
+              RETRY=$(($RETRY + 1));
+            done
       {{- end }}
       {{- end }}
       containers:

--- a/charts/opencti/templates/worker/deployment.yaml
+++ b/charts/opencti/templates/worker/deployment.yaml
@@ -49,7 +49,15 @@ spec:
         command:
           - 'sh'
           - '-c'
-          - 'RETRY=0; until [ $RETRY -eq {{ $.Values.worker.readyChecker.retries }} ]; do nc -zv {{ $.Values.fullnameOverride | default $.Release.Name }}-server {{ $.Values.service.port }} && break; echo "[$RETRY/{{ $.Values.worker.readyChecker.retries }}] waiting service {{ $.Values.fullnameOverride | default $.Release.Name }}-server:{{ $.Values.service.port }} is ready"; sleep {{ $.Values.worker.readyChecker.timeout }}; RETRY=$(($RETRY + 1)); done'
+          - >
+            RETRY=0;
+            until [ $RETRY -eq {{ $.Values.worker.readyChecker.retries }} ];
+            do
+              nc -zv {{ $.Values.fullnameOverride | default (include "opencti.fullname" .) }}-server {{ $.Values.service.port }} && break;
+              echo "[$RETRY/{{ $.Values.worker.readyChecker.retries }}] waiting service {{ $.Values.fullnameOverride | default (include "opencti.fullname" .) }}-server:{{ $.Values.service.port }} is ready";
+              sleep {{ $.Values.worker.readyChecker.timeout }};
+              RETRY=$(($RETRY + 1));
+            done
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker


### PR DESCRIPTION
<!--
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes. The PR will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

PR Steps:
1) Please make sure you test your changes before you push them.
2) Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
3) These checks run very quickly.
4) Please check the results.
5) We would like these checks to pass before we even continue reviewing your changes.
-->

#### What this PR does / why we need it:

- Use `default (include "opencti.fullname" .)` instead `$.Release.Name` on `worker` deployment.

#### Which issue this PR fixes

- closes #41 

#### Special notes for your reviewer:

N/A

#### Checklist

- [X] [DCO](https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md) signed
