### PR TITLE
[opencti] new release: 6.2.18

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/devops-ia/helm-opencti
   - https://github.com/OpenCTI-Platform/opencti
 version: 1.0.0
-appVersion: 6.2.16
+appVersion: 6.2.18
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti


### PR DESCRIPTION
OpenCTI version:
- :information_source: Current: `6.2.16`
- :up: Upgrade: `6.2.18`

Changelog: https://github.com/OpenCTI-Platform/opencti/releases/tag/6.2.18