### PR TITLE
[opencti] upgrade major dependencies (2024-09-01)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -21,22 +21,22 @@ keywords:
   - analysis
 dependencies:
   - name: elasticsearch
-    version: 21.3.8
+    version: 21.3.10
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.7.1
+    version: 14.7.4
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
-    version: 2.23.0
+    version: 2.23.1
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq
-    version: 14.6.6
+    version: 14.6.9
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 19.6.4
+    version: 20.0.3
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,11 +16,11 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.23.0 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.8 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.1 |
-| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.6 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 19.6.4 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.23.1 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.10 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.4 |
+| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.9 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.0.3 |
 
 ## Add repository
 


### PR DESCRIPTION
redis
-----

* **Current**: `19.6.4`
* **Upgrade**: `20.0.3`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/redis/20.0.3

rabbitmq
--------

* **Current**: `14.6.6`
* **Upgrade**: `14.6.9`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/rabbitmq/14.6.9

opensearch
----------

* **Current**: `2.23.0`
* **Upgrade**: `2.23.1`
* **Changelog**: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch/opensearch/2.23.1

minio
-----

* **Current**: `14.7.1`
* **Upgrade**: `14.7.4`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.7.4

elasticsearch
-------------

* **Current**: `21.3.8`
* **Upgrade**: `21.3.10`
* Changelog: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.10

