### PR TITLE
[opencti] upgrade minor dependencies (2024-09-09)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -21,15 +21,15 @@ keywords:
   - analysis
 dependencies:
   - name: elasticsearch
-    version: 21.3.10
+    version: 21.3.13
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.7.4
+    version: 14.7.5
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
-    version: 2.23.1
+    version: 2.23.2
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq
@@ -37,6 +37,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 20.0.3
+    version: 20.0.5
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,11 +16,11 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.23.1 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.10 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.4 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.23.2 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.13 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.5 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.9 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 20.0.3 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.0.5 |
 
 ## Add repository
 


### PR DESCRIPTION
opensearch
----------

* **Current**: `2.23.1`
* **Upgrade**: `2.23.2`
* **Changelog**: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch/opensearch/2.23.2

minio
-----

* **Current**: `14.7.4`
* **Upgrade**: `14.7.5`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.7.5

elasticsearch
-------------

* **Current**: `21.3.10`
* **Upgrade**: `21.3.13`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.13

redis
-----

* **Current**: `20.0.3`
* **Upgrade**: `20.0.5`
* Changelog: https://github.com/bitnami/charts/releases/tag/redis/20.0.5

