### PR TITLE
[opencti] upgrade minor dependencies (2024-09-16)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -21,22 +21,22 @@ keywords:
   - analysis
 dependencies:
   - name: elasticsearch
-    version: 21.3.13
+    version: 21.3.16
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.7.5
+    version: 14.7.8
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
-    version: 2.23.2
+    version: 2.24.0
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq
-    version: 14.6.9
+    version: 14.7.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 20.0.5
+    version: 20.1.3
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,11 +16,11 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.23.2 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.13 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.5 |
-| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.6.9 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 20.0.5 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.24.0 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.16 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.8 |
+| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.7.0 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.1.3 |
 
 ## Add repository
 


### PR DESCRIPTION
elasticsearch
-------------

* **Current**: `21.3.13`
* **Upgrade**: `21.3.16`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.16

redis
-----

* **Current**: `20.0.5`
* **Upgrade**: `20.1.3`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/redis/20.1.3

rabbitmq
--------

* **Current**: `14.6.9`
* **Upgrade**: `14.7.0`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/rabbitmq/14.7.0

opensearch
----------

* **Current**: `2.23.2`
* **Upgrade**: `2.24.0`
* **Changelog**: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch/opensearch/2.24.0

minio
-----

* **Current**: `14.7.5`
* **Upgrade**: `14.7.8`
* Changelog: https://github.com/bitnami/charts/releases/tag/minio/14.7.8

