### PR TITLE
[opencti] upgrade minor dependencies (2024-09-23)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -21,15 +21,15 @@ keywords:
   - analysis
 dependencies:
   - name: elasticsearch
-    version: 21.3.16
+    version: 21.3.17
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.7.8
+    version: 14.7.10
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
-    version: 2.24.0
+    version: 2.25.0
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq
@@ -37,6 +37,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 20.1.3
+    version: 20.1.4
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,11 +16,11 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.24.0 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.16 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.8 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.25.0 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.17 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.10 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.7.0 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 20.1.3 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.1.4 |
 
 ## Add repository
 


### PR DESCRIPTION
minio
-----

* **Current**: `14.7.8`
* **Upgrade**: `14.7.10`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.7.10

elasticsearch
-------------

* **Current**: `21.3.16`
* **Upgrade**: `21.3.17`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.17

redis
-----

* **Current**: `20.1.3`
* **Upgrade**: `20.1.4`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/redis/20.1.4

opensearch
----------

* **Current**: `2.24.0`
* **Upgrade**: `2.25.0`
* Changelog: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch/opensearch/2.25.0

