### PR TITLE
[opencti] upgrade minor dependencies (2024-09-30)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -21,11 +21,11 @@ keywords:
   - analysis
 dependencies:
   - name: elasticsearch
-    version: 21.3.17
+    version: 21.3.18
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.7.10
+    version: 14.7.13
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
@@ -37,6 +37,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 20.1.4
+    version: 20.1.5
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -17,10 +17,10 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 | Repository | Name | Version |
 |------------|------|---------|
 | https://opensearch-project.github.io/helm-charts/ | opensearch | 2.25.0 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.17 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.10 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.18 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.13 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 14.7.0 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 20.1.4 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.1.5 |
 
 ## Add repository
 


### PR DESCRIPTION
minio
-----

* **Current**: `14.7.10`
* **Upgrade**: `14.7.13`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.7.13

elasticsearch
-------------

* **Current**: `21.3.17`
* **Upgrade**: `21.3.18`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.18

redis
-----

* **Current**: `20.1.4`
* **Upgrade**: `20.1.5`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/redis/20.1.5

