### PR TITLE
[opencti] upgrade minor dependencies (2024-10-07)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -21,15 +21,15 @@ keywords:
   - analysis
 dependencies:
   - name: elasticsearch
-    version: 21.3.18
+    version: 21.3.20
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.7.13
+    version: 14.7.15
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
-    version: 2.25.0
+    version: 2.26.0
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq
@@ -37,6 +37,6 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 20.1.5
+    version: 20.1.7
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,11 +16,11 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.25.0 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.18 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.13 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.26.0 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.20 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.15 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.1 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 20.1.5 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.1.7 |
 
 ## Add repository
 


### PR DESCRIPTION
opensearch
----------

* **Current**: `2.25.0`
* **Upgrade**: `2.26.0`
* **Changelog**: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch/opensearch/2.26.0

minio
-----

* **Current**: `14.7.13`
* **Upgrade**: `14.7.15`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.7.15

elasticsearch
-------------

* **Current**: `21.3.18`
* **Upgrade**: `21.3.20`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.20

redis
-----

* **Current**: `20.1.5`
* **Upgrade**: `20.1.7`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/redis/20.1.7

