### PR TITLE
[opencti] upgrade minor dependencies (2024-10-14)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -21,7 +21,7 @@ keywords:
   - analysis
 dependencies:
   - name: elasticsearch
-    version: 21.3.20
+    version: 21.3.21
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
@@ -33,10 +33,10 @@ dependencies:
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq
-    version: 15.0.1
+    version: 15.0.2
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 20.1.7
+    version: 20.2.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -17,10 +17,10 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 | Repository | Name | Version |
 |------------|------|---------|
 | https://opensearch-project.github.io/helm-charts/ | opensearch | 2.26.0 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.20 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.21 |
 | oci://registry-1.docker.io/bitnamicharts | minio | 14.7.15 |
-| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.1 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 20.1.7 |
+| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.2 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.2.0 |
 
 ## Add repository
 


### PR DESCRIPTION
elasticsearch
-------------

* **Current**: `21.3.20`
* **Upgrade**: `21.3.21`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.21

redis
-----

* **Current**: `20.1.7`
* **Upgrade**: `20.2.0`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/redis/20.2.0

rabbitmq
--------

* **Current**: `15.0.1`
* **Upgrade**: `15.0.2`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/rabbitmq/15.0.2

