### PR TITLE
[opencti] upgrade minor dependencies (2024-10-21)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -21,11 +21,11 @@ keywords:
   - analysis
 dependencies:
   - name: elasticsearch
-    version: 21.3.21
+    version: 21.3.22
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.7.15
+    version: 14.8.0
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
@@ -33,10 +33,10 @@ dependencies:
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq
-    version: 15.0.2
+    version: 15.0.3
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis
-    version: 20.2.0
+    version: 20.2.1
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -17,10 +17,10 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 | Repository | Name | Version |
 |------------|------|---------|
 | https://opensearch-project.github.io/helm-charts/ | opensearch | 2.26.0 |
-| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.21 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.7.15 |
-| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.2 |
-| oci://registry-1.docker.io/bitnamicharts | redis | 20.2.0 |
+| oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.22 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.8.0 |
+| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.3 |
+| oci://registry-1.docker.io/bitnamicharts | redis | 20.2.1 |
 
 ## Add repository
 


### PR DESCRIPTION
rabbitmq
--------

* **Current**: `15.0.2`
* **Upgrade**: `15.0.3`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/rabbitmq/15.0.3

minio
-----

* **Current**: `14.7.15`
* **Upgrade**: `14.8.0`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.8.0

elasticsearch
-------------

* **Current**: `21.3.21`
* **Upgrade**: `21.3.22`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/elasticsearch/21.3.22

redis
-----

* **Current**: `20.2.0`
* **Upgrade**: `20.2.1`
* Changelog: https://github.com/bitnami/charts/releases/tag/redis/20.2.1

