### PR TITLE
Add support for global connector envFromSecret, env, volumes, and volumeMounts.

### DIFF
--- a/charts/opencti/templates/connector/deployment.yaml
+++ b/charts/opencti/templates/connector/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $connectorsGlobal := .Values.connectorsGlobal }}
 {{- range .Values.connectors }}
 {{- $connectorName := .name }}
 
@@ -81,6 +82,7 @@ spec:
           env:
           # Variables from secrets have precedence
           {{- $envList := dict -}}
+          # Connector specific env from secrets
           {{- if .envFromSecrets }}
           {{- range $key, $value := .envFromSecrets }}
           - name: {{ $key | upper }}
@@ -91,9 +93,32 @@ spec:
           {{- $_ := set $envList $key true }}
           {{- end }}
           {{- end }}
+          # Connectors global env from secrets
+          {{- if $connectorsGlobal.envFromSecret }}
+          {{- range $key, $value := $connectorsGlobal.envFromSecret }}
+          {{- if not (hasKey $envList $key) }}
+          - name: {{ $key | upper }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $value.name }}
+                key: {{ $value.key | default $key }}
+          {{- $_ := set $envList $key true }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
            # Add variables in plain text if they were not already added from secrets
           {{- if .env }}
           {{- range $key, $value := .env }}
+          {{- if not (hasKey $envList $key) }}
+          - name: {{ $key | upper }}
+            value: {{ $value | quote }}
+          {{- $_ := set $envList $key true }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          # Connectors global env from secrets
+          {{- if $connectorsGlobal.env }}
+          {{- range $key, $value := $connectorsGlobal.env }}
           {{- if not (hasKey $envList $key) }}
           - name: {{ $key | upper }}
             value: {{ $value | quote }}
@@ -123,7 +148,17 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .resources | nindent 12 }}
+          # Connectors global volumeMounts if defined
+          {{- with $connectorsGlobal.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds | default 30 }}
+      {{- with $connectorsGlobal.volumes }}
+      # Connectors global volumes if defined
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/opencti/values.yaml
+++ b/charts/opencti/values.yaml
@@ -348,9 +348,30 @@ topologySpreadConstraints: []
   #   topologyKey: zone
   #   whenUnsatisfiable: DoNotSchedule
 
-# -- Connector Global environment
-connectorsGlobalEnv: {}
+# -- Connectors Globals
+connectorsGlobal:
+  # -- Secrets from variables
+  envFromSecrets: {}
+  # MY_VARIABLE:
+  #  name: <release-name>-credentials
+  #  key: secret_key
+
+  # -- Additional environment variables on the output connector definition
+  env: {}
   # MY_VARIABLE: my_value
+
+  # -- Additional volumes on the output connector Deployment definition
+  volumes: []
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+  #     optional: false
+
+  # -- Additional volumeMounts on the output connector Deployment definition
+  volumeMounts: []
+  # - name: foo
+  #   mountPath: "/etc/foo"
+  #   readOnly: true
 
 # -- Connectors
 # </br> Ref: https://github.com/OpenCTI-Platform/connectors/tree/master


### PR DESCRIPTION
<!--
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes. The PR will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

PR Steps:
1) Please make sure you test your changes before you push them.
2) Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
3) These checks run very quickly.
4) Please check the results.
5) We would like these checks to pass before we even continue reviewing your changes.
-->

#### What this PR does / why we need it:

<!--
List the things that your PR does. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Adds support for global connector settings for:
1. `envFromSecret` settings,
2. `env` settings (previously defined in `values.yaml` but no implemented in deployment),
3. `volumes` on the Pod,
4. `volumeMounts` to be mounted in the containers.

#### Special notes for your reviewer:

<!--
Complete with your notes. If not applicable, remove this section or set N/A
-->
This has been tested locally to provide certificate volume mounts and connector configurations supporting access to the `opencti-server` services over HTTPS with SSL verification enabled for a private but locally trusted certificate.

#### Checklist

- [X] [DCO](https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md) signed
