### PR TITLE
[opencti] upgrade minor dependencies (2024-10-28)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
-    version: 2.26.0
+    version: 2.26.1
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -16,7 +16,7 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.26.0 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 2.26.1 |
 | oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.22 |
 | oci://registry-1.docker.io/bitnamicharts | minio | 14.8.0 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.3 |


### PR DESCRIPTION
opensearch
----------

* **Current**: `2.26.0`
* **Upgrade**: `2.26.1`
* **Changelog**: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch/opensearch/2.26.1

