### PR TITLE
[opencti] upgrade major dependencies (2024-11-01)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: elasticsearch.enabled
   - name: minio
-    version: 14.8.0
+    version: 14.8.1
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: minio.enabled
   - name: opensearch
@@ -33,7 +33,7 @@ dependencies:
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq
-    version: 15.0.3
+    version: 15.0.5
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: rabbitmq.enabled
   - name: redis

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -18,8 +18,8 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 |------------|------|---------|
 | https://opensearch-project.github.io/helm-charts/ | opensearch | 2.26.1 |
 | oci://registry-1.docker.io/bitnamicharts | elasticsearch | 21.3.22 |
-| oci://registry-1.docker.io/bitnamicharts | minio | 14.8.0 |
-| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.3 |
+| oci://registry-1.docker.io/bitnamicharts | minio | 14.8.1 |
+| oci://registry-1.docker.io/bitnamicharts | rabbitmq | 15.0.5 |
 | oci://registry-1.docker.io/bitnamicharts | redis | 20.2.1 |
 
 ## Add repository


### PR DESCRIPTION
rabbitmq
--------

* **Current**: `15.0.3`
* **Upgrade**: `15.0.5`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/rabbitmq/15.0.5

minio
-----

* **Current**: `14.8.0`
* **Upgrade**: `14.8.1`
* **Changelog**: https://github.com/bitnami/charts/releases/tag/minio/14.8.1

