### PR TITLE
Connector metric scraping: Add service and servicemonitor objects. Add port to connector to depl…

### DIFF
--- a/charts/opencti/ci/ci-common-values.yaml
+++ b/charts/opencti/ci/ci-common-values.yaml
@@ -91,6 +91,10 @@ connectors:
 - name: opencti
   enabled: true
   replicas: 1
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    scrapeTimeout: 10s
   image:
     repository: opencti/connector-opencti
   serviceAccount:

--- a/charts/opencti/docs/examples.md
+++ b/charts/opencti/docs/examples.md
@@ -384,3 +384,23 @@ spec:
     spec:
       serviceAccountName: sample-misp-connector-opencti
 ```
+
+### Configure metrics
+
+You can enable Prometheus metric scraping with a serviceMonitor object
+```yaml
+connectors:
+- name: sample-misp
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    scrapeTimeout: 10s
+  env:
+    ...
+    CONNECTOR_EXPOSE_METRICS: true
+    ...
+```
+
+The `interval` and `scrapeTimeout` are optional and can be omitted in order to use the defaults. Make sure to set the enviroment variable `CONNECTOR_EXPOSE_METRICS` to `true`. 
+

--- a/charts/opencti/templates/connector/deployment.yaml
+++ b/charts/opencti/templates/connector/deployment.yaml
@@ -75,6 +75,12 @@ spec:
             {{- toYaml .securityContext | nindent 12 }}
           image: "{{- if and .image (hasKey .image "repository") }}{{ .image.repository }}{{- else if $.Values.global.imageRegistry }}{{ printf "%s/opencti/%s" $.Values.global.imageRegistry .name }}{{- else }}{{ printf "opencti/%s" .name }}{{- end }}:{{ if and .image (hasKey .image "tag") }}{{ .image.tag | default $.Chart.AppVersion }}{{ else }}{{ $.Chart.AppVersion }}{{ end }}"
           imagePullPolicy: {{ if and .image (hasKey .image "pullPolicy") }}{{ .image.pullPolicy }}{{ else }}IfNotPresent{{ end }}
+          ports:
+            {{- if ((.serviceMonitor).enabled) }}
+            - name: metrics
+              containerPort: {{ .env.CONNECTOR_METRICS_PORT | default 9095 }}
+              protocol: TCP
+            {{- end }}
           lifecycle:
             {{- with .lifecycle }}
             {{- toYaml . | nindent 12 }}

--- a/charts/opencti/templates/connector/service.yaml
+++ b/charts/opencti/templates/connector/service.yaml
@@ -1,0 +1,28 @@
+{{- $connectorsGlobal := .Values.connectorsGlobal }}
+{{- $serviceType := .Values.service.type }}
+
+{{- range .Values.connectors }}
+{{- $connectorName := .name }}
+{{- if and .enabled .env.CONNECTOR_EXPOSE_METRICS }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $connectorName }}-service-{{ include "opencti.fullname" $ }}
+  labels:
+    opencti.connector: {{ $connectorName }}
+    {{- include "opencti.labels" $ | nindent 4 }}
+spec:
+  type: {{ $serviceType }}
+  ports:
+    {{- if .env.CONNECTOR_EXPOSE_METRICS }}
+    - name: metrics
+      port: {{ .env.CONNECTOR_METRICS_PORT | default 9095 }}
+      targetPort: {{ .env.CONNECTOR_METRICS_PORT | default 9095 }}
+      protocol: TCP
+    {{- end }}
+  selector:
+    opencti.connector: {{ $connectorName }}
+    {{- include "opencti.selectorLabels" $ | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/opencti/templates/connector/servicemonitor.yaml
+++ b/charts/opencti/templates/connector/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- $connectorsGlobal := .Values.connectorsGlobal }}
+{{- range .Values.connectors }}
+{{- $connectorName := .name }}
+
+{{- if and ((.serviceMonitor).enabled) .env.CONNECTOR_EXPOSE_METRICS }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $connectorName }}
+  labels:
+    opencti.connector: {{ $connectorName }}
+    {{- include "opencti.labels" $ | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      opencti.connector: {{ $connectorName }}
+      {{- include "opencti.selectorLabels" $ | nindent 6 }}
+  endpoints:
+  - port: metrics
+    interval: {{ default "30s" .serviceMonitor.interval | quote }}
+    scrapeTimeout: {{ default "10s" .serviceMonitor.scrapeTimeout | quote }}
+    {{- if .serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml .serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
+    {{- if .serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+{{- end -}}
+{{- end }}


### PR DESCRIPTION
This PR is meant to address issue #85.

The PR contains a deployment for a service and a service monitor.

The intended behaviour is that if:

- Metrics are enabled on the pod -> Service deployment is created
- serviceMonitor is enabled -> the serviceMonitor deployment is created _if_ metrics are also enabled in the container

Considerations:
- The service deployment is not created if the metrics are not enabled as there are no other ports to expose, and the service deployment would be 'empty'
- As connectors cannot be specified in the default values I have made the servicemonitor value optional with defaults within the chart. 

