### PR TITLE
[opencti] new release: 6.4.11

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/devops-ia/helm-opencti
   - https://github.com/OpenCTI-Platform/opencti
 version: 1.0.0
-appVersion: 6.4.10
+appVersion: 6.4.11
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti


### PR DESCRIPTION
OpenCTI version:
- :information_source: Current: `6.4.10`
- :up: Upgrade: `6.4.11`

Changelog: https://github.com/OpenCTI-Platform/opencti/releases/tag/6.4.11