### PR TITLE
[opencti] new release: 6.5.6

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/devops-ia/helm-opencti
   - https://github.com/OpenCTI-Platform/opencti
 version: 1.0.0
-appVersion: 6.5.5
+appVersion: 6.5.6
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti


### PR DESCRIPTION
Hello, thanks for your work! I saw this new version released, and have created a PR similar to previous upgrades. Feel free to tweak as you see fit.

---

OpenCTI version:

- ℹ️  Current: 6.5.5
- 🆙 Upgrade: 6.5.6

Changelog: <https://github.com/OpenCTI-Platform/opencti/releases/tag/6.5.6>
