### PR TITLE
[opencti] new release: 6.6.1

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -10,7 +10,7 @@ sources:
   - https://github.com/devops-ia/helm-opencti
   - https://github.com/OpenCTI-Platform/opencti
 version: 1.0.0
-appVersion: 6.5.11
+appVersion: 6.6.1
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti


### PR DESCRIPTION
OpenCTI version:
- :information_source: Current: `6.5.11`
- :up: Upgrade: `6.6.1`

Changelog: https://github.com/OpenCTI-Platform/opencti/releases/tag/6.6.1