### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,5 +1,8 @@
 name: Lint and test PR OpenCTI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-opencti/security/code-scanning/4](https://github.com/devops-ia/helm-opencti/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Based on the steps in the workflow, it appears that only `contents: read` is necessary, as the workflow primarily involves reading repository contents and running tests. No write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
