### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-opencti-release.yaml
+++ b/.github/workflows/check-opencti-release.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * *' # every day
 
+permissions:
+  contents: write
+
 jobs:
   check-and-update-opencti:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-opencti/security/code-scanning/3](https://github.com/devops-ia/helm-opencti/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Based on the workflow's actions:
- `contents: write` is needed for creating pull requests and updating the README.md Helm Chart.
- `contents: read` is sufficient for other steps that only read repository files.
- No other permissions appear to be required.

The `permissions` block will be added at the root of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
