### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-opencti-major-dependencies.yaml
+++ b/.github/workflows/check-opencti-major-dependencies.yaml
@@ -1,5 +1,9 @@
 name: Check OpenCTI major dependencies releases
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-opencti/security/code-scanning/2](https://github.com/devops-ia/helm-opencti/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow to define the minimal permissions required for the `GITHUB_TOKEN`. Based on the workflow's operations, the following permissions are needed:
- `contents: read` for reading repository contents.
- `contents: write` for updating dependencies and committing changes.
- `pull-requests: write` for creating pull requests.

The `permissions` block should be added at the top level of the workflow, ensuring all jobs inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
