### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-opencti-minor-dependencies.yaml
+++ b/.github/workflows/check-opencti-minor-dependencies.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 0 * * 1' # every monday
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-and-update-minor-dependencies:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/devops-ia/helm-opencti/security/code-scanning/1](https://github.com/devops-ia/helm-opencti/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are necessary:
- `contents: read` for reading repository contents.
- `contents: write` for creating pull requests and updating files.
- `pull-requests: write` for creating and managing pull requests.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
