### PR TITLE
[opencti] new release: 6.7.20

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/devops-ia/helm-opencti
   - https://github.com/OpenCTI-Platform/opencti
 version: 1.0.0
-appVersion: 6.7.19
+appVersion: 6.7.20
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti


### PR DESCRIPTION
OpenCTI version:
- :information_source: Current: `6.7.19`
- :up: Upgrade: `6.7.20`

Changelog: https://github.com/OpenCTI-Platform/opencti/releases/tag/6.7.20