### PR TITLE
Remove duplicated label/selector opencti.component

### DIFF
--- a/charts/opencti/templates/server/_deployment.tpl
+++ b/charts/opencti/templates/server/_deployment.tpl
@@ -22,7 +22,6 @@ metadata:
     {{- end }}
     {{- else }}
     {{- include "opencti.serverLabels" . | nindent 4 }}
-    opencti.component: {{ $serverType }}
     {{- end }}
 spec:
   {{- if not .Values.clustering.enabled }}
@@ -46,7 +45,6 @@ spec:
       {{- end }}
       {{- else }}
       {{- include "opencti.selectorServerLabels" . | nindent 6 }}
-      opencti.component: {{ $serverType }}
       {{- end }}
   template:
     metadata:
@@ -63,7 +61,6 @@ spec:
         {{- end }}
         {{- else }}
         {{- include "opencti.selectorServerLabels" . | nindent 8 }}
-        opencti.component: {{ $serverType }}
         {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Remove the opencti.component label and selector that is already added by the opencti.serverLabels and opencti.selectorServerLabels helper function.

<!--
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* c
* https://helm.sh/docs/chart_best_practices/

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes. The PR will be squashed anyways when it is merged.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

PR Steps:
1) Please make sure you test your changes before you push them.
2) Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
3) These checks run very quickly.
4) Please check the results.
5) We would like these checks to pass before we even continue reviewing your changes.
-->

#### What this PR does / why we need it:

See issue #253 

<!--
List the things that your PR does. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

#### Which issue this PR fixes

- fixes #253 

#### Special notes for your reviewer:

<!--
Complete with your notes. If not applicable, remove this section or set N/A
-->

#### Checklist

- [x ] [DCO](https://github.com/devops-ia/.github/blob/main/CONTRIBUTING.md) signed
