### PR TITLE
[opencti] upgrade major dependencies (2025-11-01)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -22,7 +22,7 @@ keywords:
   - analysis
 dependencies:
   - name: eck-stack
-    version: 0.16.0
+    version: 0.17.0
     repository: https://helm.elastic.co
     condition: eck-stack.enabled
   - name: minio
@@ -30,7 +30,7 @@ dependencies:
     repository: https://charts.min.io/
     condition: minio.enabled
   - name: opensearch
-    version: 3.3.1
+    version: 3.3.2
     repository: https://opensearch-project.github.io/helm-charts/
     condition: opensearch.enabled
   - name: rabbitmq

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -22,8 +22,8 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.min.io/ | minio | 5.4.0 |
-| https://helm.elastic.co | eck-stack | 0.16.0 |
-| https://opensearch-project.github.io/helm-charts/ | opensearch | 3.3.1 |
+| https://helm.elastic.co | eck-stack | 0.17.0 |
+| https://opensearch-project.github.io/helm-charts/ | opensearch | 3.3.2 |
 | oci://ghcr.io/dragonflydb/dragonfly/helm | redis(dragonfly) | v1.34.2 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 16.0.13 |
 


### PR DESCRIPTION


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline ".github/updatecli/helm-dependencies.yaml"

SCM repository retrieved: 0


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



##########################
# HELM-DEPENDENCIES.YAML #
##########################

source: source#rabbitmq
---------------
Searching for version matching pattern "*"
✔ OCI version "16.0.14" found matching pattern "*"

source: source#dragonfly
----------------
Searching for version matching pattern "*"
✔ Docker Image Tag "v1.34.2" found matching pattern "*"

target: target#dragonfly
----------------
✔ - no change detected:
	* key "$.dependencies[4].version" already set to "v1.34.2", from file "charts/opencti/Chart.yaml"

source: source#minio
------------
Searching for version matching pattern "*"
✔ Helm Chart "minio" version "5.4.0" is found from repository "https://charts.min.io/"

source: source#eck-stack
----------------
Searching for version matching pattern "*"
✔ Helm Chart "eck-stack" version "0.17.0" is found from repository "https://helm.elastic.co"

source: source#opensearch
-----------------
Searching for version matching pattern "*"
✔ Helm Chart "opensearch" version "3.3.2" is found from repository "https://opensearch-project.github.io/helm-charts/"

target: target#minio
------------
✔ - no change detected:
	* key "$.dependencies[1].version" already set to "5.4.0", from file "charts/opencti/Chart.yaml"


CHANGELOG:
----------

Title: 5.4.0
Published At: 2025-01-02 21:34:25.234658257 -0800 -0800
Link: 
Description: 
Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: minio
High Performance Object Storage
Project Home: https://min.io

Version created on the 2025-01-02 21:34:25.234658257 -0800 -0800

Sources:

* https://github.com/minio/minio



URL:

* https://charts.min.io/helm-releases/minio-5.4.0.tgz




target: target#eck-stack
----------------
⚠ - change detected:
	* key "$.dependencies[0].version" updated from "0.16.0" to "0.17.0", in file "charts/opencti/Chart.yaml"


CHANGELOG:
----------

Title: 0.16.0
Published At: 2025-10-30 11:49:30.996189707 +0000 UTC
Link: 
Description: 
Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: eck-stack
Elastic Stack managed by the ECK Operator

Require Kubernetes Version: &gt;= 1.21.0-0
Version created on the 2025-10-30 11:49:30.996189707 &#43;0000 UTC


URL:

* https://helm.elastic.co/helm/eck-stack/eck-stack-0.17.0.tgz




target: target#opensearch
-----------------
⚠ - change detected:
	* key "$.dependencies[2].version" updated from "3.3.1" to "3.3.2", in file "charts/opencti/Chart.yaml"


CHANGELOG:
----------

Title: 3.3.1
Published At: 2025-10-30 21:03:46.683545488 +0000 UTC
Link: 
Description: 
Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: opensearch
A Helm chart for OpenSearch
Project Home: https://opensearch.org

Version created on the 2025-10-30 21:03:46.683545488 &#43;0000 UTC

Sources:

* https://github.com/opensearch-project/opensearch

* https://github.com/opensearch-project/helm-charts



URL:

* https://github.com/opensearch-project/helm-charts/releases/download/opensearch-3.3.2/opensearch-3.3.2.tgz





ACTIONS
========


=============================

SUMMARY:



⚠ HELM-DEPENDENCIES.YAML:
	Source:
		✔ [dragonfly] 
		✔ [eck-stack] 
		✔ [minio] 
		✔ [opensearch] 
		✔ [rabbitmq] 
	Target:
		✔ [dragonfly] bump chart dependencies
		⚠ [eck-stack] bump chart dependencies
		✔ [minio] bump chart dependencies
		⚠ [opensearch] bump chart dependencies


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1

