### PR TITLE
[opencti] upgrade minor dependencies (2025-11-24)

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -41,4 +41,4 @@ dependencies:
     alias: redis
     condition: redis.enabled
     repository: oci://ghcr.io/dragonflydb/dragonfly/helm
-    version: v1.34.2
+    version: v1.35.0

--- a/charts/opencti/README.md
+++ b/charts/opencti/README.md
@@ -24,7 +24,7 @@ A Helm chart to deploy Open Cyber Threat Intelligence platform
 | https://charts.min.io/ | minio | 5.4.0 |
 | https://helm.elastic.co | eck-stack | 0.17.0 |
 | https://opensearch-project.github.io/helm-charts/ | opensearch | 3.3.2 |
-| oci://ghcr.io/dragonflydb/dragonfly/helm | redis(dragonfly) | v1.34.2 |
+| oci://ghcr.io/dragonflydb/dragonfly/helm | redis(dragonfly) | v1.35.0 |
 | oci://registry-1.docker.io/bitnamicharts | rabbitmq | 16.0.13 |
 
 ## Add repository


### PR DESCRIPTION


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline ".github/updatecli/helm-dependencies.yaml"

SCM repository retrieved: 0


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



##########################
# HELM-DEPENDENCIES.YAML #
##########################

source: source#minio
------------
Searching for version matching pattern "~5"
✔ Helm Chart "minio" version "5.4.0" is found from repository "https://charts.min.io/"

target: target#minio
------------
✔ - no change detected:
	* key "$.dependencies[1].version" already set to "5.4.0", from file "charts/opencti/Chart.yaml"


CHANGELOG:
----------

Title: 5.4.0
Published At: 2025-01-02 21:34:25.234658257 -0800 -0800
Link: 
Description: 
Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: minio
High Performance Object Storage
Project Home: https://min.io

Version created on the 2025-01-02 21:34:25.234658257 -0800 -0800

Sources:

* https://github.com/minio/minio



URL:

* https://charts.min.io/helm-releases/minio-5.4.0.tgz




source: source#dragonfly
----------------
Searching for version matching pattern "~v1"
✔ Docker Image Tag "v1.35.0" found matching pattern "~v1"

source: source#rabbitmq
---------------
Searching for version matching pattern "~16"
✔ OCI version "16.0.14" found matching pattern "~16"

source: source#eck-stack
----------------
Searching for version matching pattern "~0"
✔ Helm Chart "eck-stack" version "0.17.0" is found from repository "https://helm.elastic.co"

source: source#opensearch
-----------------
Searching for version matching pattern "~3"
✔ Helm Chart "opensearch" version "3.3.2" is found from repository "https://opensearch-project.github.io/helm-charts/"

target: target#dragonfly
----------------
⚠ - change detected:
	* key "$.dependencies[4].version" updated from "v1.34.2" to "v1.35.0", in file "charts/opencti/Chart.yaml"

target: target#eck-stack
----------------
✔ - no change detected:
	* key "$.dependencies[0].version" already set to "0.17.0", from file "charts/opencti/Chart.yaml"


CHANGELOG:
----------

Title: 0.17.0
Published At: 2025-10-30 11:49:30.996189707 +0000 UTC
Link: 
Description: 
Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: eck-stack
Elastic Stack managed by the ECK Operator

Require Kubernetes Version: &gt;= 1.21.0-0
Version created on the 2025-10-30 11:49:30.996189707 &#43;0000 UTC


URL:

* https://helm.elastic.co/helm/eck-stack/eck-stack-0.17.0.tgz




target: target#opensearch
-----------------
✔ - no change detected:
	* key "$.dependencies[2].version" already set to "3.3.2", from file "charts/opencti/Chart.yaml"


CHANGELOG:
----------

Title: 3.3.2
Published At: 2025-10-30 21:03:46.683545488 +0000 UTC
Link: 
Description: 
Remark: We couldn't identify a way to automatically retrieve changelog information.
Please use following information to take informed decision

Helm Chart: opensearch
A Helm chart for OpenSearch
Project Home: https://opensearch.org

Version created on the 2025-10-30 21:03:46.683545488 &#43;0000 UTC

Sources:

* https://github.com/opensearch-project/opensearch

* https://github.com/opensearch-project/helm-charts



URL:

* https://github.com/opensearch-project/helm-charts/releases/download/opensearch-3.3.2/opensearch-3.3.2.tgz





ACTIONS
========


=============================

SUMMARY:



⚠ HELM-DEPENDENCIES.YAML:
	Source:
		✔ [dragonfly] 
		✔ [eck-stack] 
		✔ [minio] 
		✔ [opensearch] 
		✔ [rabbitmq] 
	Target:
		⚠ [dragonfly] bump chart dependencies
		✔ [eck-stack] bump chart dependencies
		✔ [minio] bump chart dependencies
		✔ [opensearch] bump chart dependencies


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1

