### PR TITLE
fix: [opencti] new release: 7.260907.0

### DIFF
--- a/charts/opencti/Chart.yaml
+++ b/charts/opencti/Chart.yaml
@@ -11,7 +11,7 @@ sources:
   - https://github.com/devops-ia/helm-opencti
   - https://github.com/OpenCTI-Platform/opencti
 version: 2.0.0
-appVersion: 7.260904.0
+appVersion: 7.260907.0
 home: https://www.filigran.io/en/solutions/products/opencti/
 keywords:
   - opencti


### PR DESCRIPTION
OpenCTI version:
- :information_source: Current: `7.260904.0`
- :up: Upgrade: `7.260907.0`

Changelog: https://github.com/OpenCTI-Platform/opencti/releases/tag/7.260907.0